### PR TITLE
Add enum-based event bus provider

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,6 +44,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.2" />
+    <PackageVersion Include="RabbitMQ.Client" Version="6.5.0" />
   </ItemGroup>
   <!-- API & Documentation -->
   <ItemGroup>

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,6 +9,8 @@ services:
     environment:
       - ConnectionStrings__DefaultConnection=Host=ecommerce.db;Database=ecommerce;Username=postgres;Password=postgres
       - ConnectionStrings__Redis=ecommerce.redis:6379
+      - RabbitMQ__ConnectionString=amqp://guest:guest@ecommerce.rabbitmq:5672/
+      - EventBus__Provider=RabbitMQ
       - ASPNETCORE_URLS=http://+:8080
       - ASPNETCORE_ENVIRONMENT=Development
       - Serilog__WriteTo__1__Args__serverUrl=http://ecommerce.seq:5341
@@ -23,6 +25,7 @@ services:
       - ecommerce.redis
       - ecommerce.seq
       - ecommerce.authserver
+      - ecommerce.rabbitmq
     ports:
       - 4000:8080
     volumes:
@@ -126,6 +129,15 @@ services:
       - ACCEPT_EULA=Y
     volumes:
       - seqdata:/data
+    networks:
+      - ecommerce-network
+
+  ecommerce.rabbitmq:
+    container_name: ecommerce.rabbitmq
+    image: rabbitmq:3-management
+    ports:
+      - 5672:5672
+      - 15672:15672
     networks:
       - ecommerce-network
 

--- a/src/Core/ECommerce.Application/DependencyInjection.cs
+++ b/src/Core/ECommerce.Application/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using ECommerce.Application.Behaviors;
+using ECommerce.Application.Extensions;
 using ECommerce.Application.Features.Categories.Commands;
 using ECommerce.Application.Features.Categories;
 using ECommerce.Application.Helpers;
@@ -33,6 +34,8 @@ public static class DependencyInjection
         services.AddSingleton<ILazyServiceProvider, LazyServiceProvider>();
 
         services.AddScoped<CategoryBusinessRules>();
+
+        services.AddIntegrationEventHandlers();
 
         return services;
     }

--- a/src/Core/ECommerce.Application/Extensions/IntegrationEventRegistrationExtensions.cs
+++ b/src/Core/ECommerce.Application/Extensions/IntegrationEventRegistrationExtensions.cs
@@ -1,0 +1,19 @@
+using ECommerce.SharedKernel.Events;
+using Microsoft.Extensions.DependencyInjection;
+using Scrutor;
+
+namespace ECommerce.Application.Extensions;
+
+public static class IntegrationEventRegistrationExtensions
+{
+    public static IServiceCollection AddIntegrationEventHandlers(this IServiceCollection services)
+    {
+        services.Scan(scan => scan
+            .FromAssemblies(typeof(IntegrationEventRegistrationExtensions).Assembly)
+            .AddClasses(c => c.AssignableTo(typeof(IIntegrationEventHandler<>)))
+            .AsImplementedInterfaces()
+            .WithTransientLifetime());
+
+        return services;
+    }
+}

--- a/src/Core/ECommerce.Application/Interfaces/IEventBus.cs
+++ b/src/Core/ECommerce.Application/Interfaces/IEventBus.cs
@@ -1,0 +1,9 @@
+namespace ECommerce.Application.Interfaces;
+
+using ECommerce.SharedKernel.Events;
+
+public interface IEventBus
+{
+    Task PublishAsync<TEvent>(TEvent @event, CancellationToken cancellationToken = default)
+        where TEvent : class, IIntegrationEvent;
+}

--- a/src/Core/ECommerce.Application/Interfaces/IEventBusFactory.cs
+++ b/src/Core/ECommerce.Application/Interfaces/IEventBusFactory.cs
@@ -1,0 +1,6 @@
+namespace ECommerce.Application.Interfaces;
+
+public interface IEventBusFactory
+{
+    IEventBus Create(IServiceProvider serviceProvider);
+}

--- a/src/Core/ECommerce.SharedKernel/Events/IIntegrationEvent.cs
+++ b/src/Core/ECommerce.SharedKernel/Events/IIntegrationEvent.cs
@@ -1,0 +1,8 @@
+namespace ECommerce.SharedKernel.Events;
+
+/// <summary>
+/// Marker interface for integration events used by external message brokers.
+/// </summary>
+public interface IIntegrationEvent
+{
+}

--- a/src/Core/ECommerce.SharedKernel/Events/IIntegrationEventHandler.cs
+++ b/src/Core/ECommerce.SharedKernel/Events/IIntegrationEventHandler.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ECommerce.SharedKernel.Events;
+
+/// <summary>
+/// Defines a handler for a specific integration event type.
+/// </summary>
+/// <typeparam name="TEvent">Integration event type.</typeparam>
+public interface IIntegrationEventHandler<in TEvent> where TEvent : IIntegrationEvent
+{
+    Task HandleAsync(TEvent @event, CancellationToken cancellationToken = default);
+}

--- a/src/Infrastructure/ECommerce.Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/ECommerce.Infrastructure/DependencyInjection.cs
@@ -1,6 +1,7 @@
 using ECommerce.Application.Interfaces;
 using ECommerce.Application.Services;
 using ECommerce.Infrastructure.Services;
+using ECommerce.Infrastructure.Messaging;
 using ECommerce.Persistence.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,6 +17,7 @@ public static class DependencyInjection
     {
         services.AddInfraServices();
         services.AddLogging(configuration);
+        services.Configure<RabbitMqOptions>(configuration.GetSection("RabbitMQ"));
 
         services.AddStackExchangeRedisCache(options =>
         {
@@ -32,6 +34,9 @@ public static class DependencyInjection
         services.AddScoped<IIdentityService, IdentityService>();
         services.AddScoped<IUnitOfWork, UnitOfWork>();
         services.AddScoped<IPermissionService, PermissionService>();
+        services.AddSingleton<IEventBusFactory, EventBusFactory>();
+        services.AddSingleton<IEventBus>(sp =>
+            sp.GetRequiredService<IEventBusFactory>().Create(sp));
     }
 
     private static void AddLogging(this IServiceCollection services, IConfiguration configuration)

--- a/src/Infrastructure/ECommerce.Infrastructure/ECommerce.Infrastructure.csproj
+++ b/src/Infrastructure/ECommerce.Infrastructure/ECommerce.Infrastructure.csproj
@@ -23,6 +23,7 @@
       <PackageReference Include="Serilog.Sinks.Console" />
       <PackageReference Include="Serilog.Sinks.File" />
       <PackageReference Include="Serilog.Sinks.Seq" />
+      <PackageReference Include="RabbitMQ.Client" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Infrastructure/ECommerce.Infrastructure/Messaging/EventBusFactory.cs
+++ b/src/Infrastructure/ECommerce.Infrastructure/Messaging/EventBusFactory.cs
@@ -1,0 +1,34 @@
+using ECommerce.Application.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace ECommerce.Infrastructure.Messaging;
+
+/// <summary>
+/// Factory for creating the configured <see cref="IEventBus"/> implementation.
+/// Currently only supports RabbitMQ.
+/// </summary>
+public sealed class EventBusFactory : IEventBusFactory
+{
+    private readonly EventBusProvider _provider;
+
+    public EventBusFactory(IConfiguration configuration)
+    {
+        var providerString = configuration["EventBus:Provider"] ?? nameof(EventBusProvider.RabbitMQ);
+        if (!Enum.TryParse(providerString, ignoreCase: true, out EventBusProvider parsed))
+        {
+            parsed = EventBusProvider.RabbitMQ;
+        }
+        _provider = parsed;
+    }
+
+    public IEventBus Create(IServiceProvider serviceProvider)
+    {
+        return _provider switch
+        {
+            EventBusProvider.RabbitMQ => new RabbitMqEventBus(serviceProvider.GetRequiredService<IOptions<RabbitMqOptions>>()),
+            _ => throw new NotSupportedException($"Event bus provider '{_provider}' is not supported")
+        };
+    }
+}

--- a/src/Infrastructure/ECommerce.Infrastructure/Messaging/EventBusProvider.cs
+++ b/src/Infrastructure/ECommerce.Infrastructure/Messaging/EventBusProvider.cs
@@ -1,0 +1,6 @@
+namespace ECommerce.Infrastructure.Messaging;
+
+public enum EventBusProvider
+{
+    RabbitMQ
+}

--- a/src/Infrastructure/ECommerce.Infrastructure/Messaging/RabbitMqEventBus.cs
+++ b/src/Infrastructure/ECommerce.Infrastructure/Messaging/RabbitMqEventBus.cs
@@ -1,0 +1,59 @@
+using System.Text;
+using System.Text.Json;
+using ECommerce.Application.Interfaces;
+using ECommerce.SharedKernel.Events;
+using Microsoft.Extensions.Options;
+using RabbitMQ.Client;
+
+namespace ECommerce.Infrastructure.Messaging;
+
+public sealed class RabbitMqEventBus(IOptions<RabbitMqOptions> options) : IEventBus, IDisposable
+{
+    private readonly IConnection _connection;
+    private readonly IModel _channel;
+
+    public RabbitMqEventBus(IOptions<RabbitMqOptions> options)
+        : this(new ConnectionFactory { Uri = new Uri(options.Value.ConnectionString) })
+    {
+    }
+
+    private RabbitMqEventBus(IConnectionFactory factory)
+    {
+        _connection = factory.CreateConnection();
+        _channel = _connection.CreateModel();
+    }
+
+    public Task PublishAsync<TEvent>(TEvent @event, CancellationToken cancellationToken = default) where TEvent : class, IIntegrationEvent
+    {
+        var exchange = typeof(TEvent).Name;
+        EnsureExchange(exchange);
+
+        var body = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(@event));
+        var properties = _channel.CreateBasicProperties();
+        properties.DeliveryMode = 2; // persistent
+
+        _channel.BasicPublish(exchange, routingKey: string.Empty, properties: properties, body: body);
+        return Task.CompletedTask;
+    }
+
+    private void EnsureExchange(string exchange)
+    {
+        _channel.ExchangeDeclare(exchange, ExchangeType.Fanout, durable: true, autoDelete: false);
+    }
+
+    public void CreateQueue(string queueName)
+    {
+        _channel.QueueDeclare(queueName, durable: true, exclusive: false, autoDelete: false);
+    }
+
+    public void BindQueue(string queueName, string exchange)
+    {
+        _channel.QueueBind(queueName, exchange, routingKey: string.Empty);
+    }
+
+    public void Dispose()
+    {
+        _channel.Close();
+        _connection.Close();
+    }
+}

--- a/src/Infrastructure/ECommerce.Infrastructure/Messaging/RabbitMqOptions.cs
+++ b/src/Infrastructure/ECommerce.Infrastructure/Messaging/RabbitMqOptions.cs
@@ -1,0 +1,6 @@
+namespace ECommerce.Infrastructure.Messaging;
+
+public sealed record RabbitMqOptions
+{
+    public string ConnectionString { get; init; } = string.Empty;
+}

--- a/src/Presentation/ECommerce.WebAPI/appsettings.json
+++ b/src/Presentation/ECommerce.WebAPI/appsettings.json
@@ -29,6 +29,12 @@
     "DefaultConnection": "Host=localhost;Database=ecommerce;Username=postgres;Password=postgres;",
     "Redis": "localhost:6379"
   },
+  "RabbitMQ": {
+    "ConnectionString": "amqp://guest:guest@localhost:5672/"
+  },
+  "EventBus": {
+    "Provider": "RabbitMQ"
+  },
   "Authentication": {
     "Authority": "https://localhost:5002",
     "Audience": "api",


### PR DESCRIPTION
## Summary
- add `EventBusProvider` enum
- use enum in `EventBusFactory`
- configure provider in `appsettings.json`
- pass provider setting via docker compose

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685135955c4c8321808eac6875e22b49