### PR TITLE
Add marker interfaces and automatic DI registration

### DIFF
--- a/src/Core/ECommerce.Application/DependencyInjection.cs
+++ b/src/Core/ECommerce.Application/DependencyInjection.cs
@@ -15,6 +15,7 @@ public static class DependencyInjection
     public static IServiceCollection AddApplication(this IServiceCollection services)
     {
         var assembly = typeof(DependencyInjection).Assembly;
+        services.AddDependencies(assembly);
 
         services.AddValidatorsFromAssemblyContaining<CreateCategoryCommandValidator>(includeInternalTypes: true);
 

--- a/src/Core/ECommerce.Application/Features/Categories/CategoryBusinessRules.cs
+++ b/src/Core/ECommerce.Application/Features/Categories/CategoryBusinessRules.cs
@@ -1,8 +1,9 @@
 using ECommerce.Application.Repositories;
+using ECommerce.SharedKernel;
 
 namespace ECommerce.Application.Features.Categories;
 
-public sealed class CategoryBusinessRules(ICategoryRepository categoryRepository)
+public sealed class CategoryBusinessRules(ICategoryRepository categoryRepository) : IScopedDependency
 {
     public async Task<bool> CheckIfCategoryExistsAsync(string name, Guid? excludeId = null, CancellationToken cancellationToken = default)
     {

--- a/src/Core/ECommerce.Application/Helpers/LocalizationHelper.cs
+++ b/src/Core/ECommerce.Application/Helpers/LocalizationHelper.cs
@@ -1,8 +1,9 @@
 using ECommerce.Application.Interfaces;
+using ECommerce.SharedKernel;
 
 namespace ECommerce.Application.Helpers;
 
-public class LocalizationHelper(ILocalizationService localizationService)
+public class LocalizationHelper(ILocalizationService localizationService) : IScopedDependency
 {
     public string this[string key] => localizationService.GetLocalizedString(key);
     public string this[string key, string language] => localizationService.GetLocalizedString(key, language);

--- a/src/Core/ECommerce.SharedKernel/DependencyInjectionExtensions.cs
+++ b/src/Core/ECommerce.SharedKernel/DependencyInjectionExtensions.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Scrutor;
+
+namespace ECommerce.SharedKernel;
+
+public static class DependencyInjectionExtensions
+{
+    public static IServiceCollection AddDependencies(this IServiceCollection services, params Assembly[] assemblies)
+    {
+        assemblies = assemblies.Length == 0 ? new[] { Assembly.GetCallingAssembly() } : assemblies;
+
+        services.Scan(scan => scan
+            .FromAssemblies(assemblies)
+            .AddClasses(c => c.AssignableTo<IScopedDependency>())
+                .UsingRegistrationStrategy(RegistrationStrategy.Skip)
+                .AsImplementedInterfaces()
+                .WithScopedLifetime()
+            .AddClasses(c => c.AssignableTo<ISingletonDependency>())
+                .UsingRegistrationStrategy(RegistrationStrategy.Skip)
+                .AsImplementedInterfaces()
+                .WithSingletonLifetime()
+            .AddClasses(c => c.AssignableTo<ITransientDependency>())
+                .UsingRegistrationStrategy(RegistrationStrategy.Skip)
+                .AsImplementedInterfaces()
+                .WithTransientLifetime());
+
+        return services;
+    }
+}

--- a/src/Core/ECommerce.SharedKernel/IScopedDependency.cs
+++ b/src/Core/ECommerce.SharedKernel/IScopedDependency.cs
@@ -1,0 +1,5 @@
+namespace ECommerce.SharedKernel;
+
+public interface IScopedDependency
+{
+}

--- a/src/Core/ECommerce.SharedKernel/ISingletonDependency.cs
+++ b/src/Core/ECommerce.SharedKernel/ISingletonDependency.cs
@@ -1,0 +1,5 @@
+namespace ECommerce.SharedKernel;
+
+public interface ISingletonDependency
+{
+}

--- a/src/Core/ECommerce.SharedKernel/ITransientDependency.cs
+++ b/src/Core/ECommerce.SharedKernel/ITransientDependency.cs
@@ -1,0 +1,5 @@
+namespace ECommerce.SharedKernel;
+
+public interface ITransientDependency
+{
+}

--- a/src/Core/ECommerce.SharedKernel/LazyServiceProvider.cs
+++ b/src/Core/ECommerce.SharedKernel/LazyServiceProvider.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace ECommerce.SharedKernel;
 
-public sealed class LazyServiceProvider : ILazyServiceProvider
+public sealed class LazyServiceProvider : ILazyServiceProvider, ITransientDependency
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly ConcurrentDictionary<Type, Lazy<object?>> _lazyServices;

--- a/src/Infrastructure/ECommerce.Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/ECommerce.Infrastructure/DependencyInjection.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using ECommerce.Infrastructure.Logging;
 using Serilog;
 using ECommerce.SharedKernel.Logging;
+using ECommerce.SharedKernel;
 
 namespace ECommerce.Infrastructure;
 
@@ -15,6 +16,7 @@ public static class DependencyInjection
     public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddInfraServices();
+        services.AddDependencies(typeof(DependencyInjection).Assembly);
         services.AddLogging(configuration);
 
         services.AddStackExchangeRedisCache(options =>

--- a/src/Infrastructure/ECommerce.Infrastructure/Services/CacheService.cs
+++ b/src/Infrastructure/ECommerce.Infrastructure/Services/CacheService.cs
@@ -1,10 +1,11 @@
 using System.Text.Json;
 using ECommerce.Application.Interfaces;
+using ECommerce.SharedKernel;
 using Microsoft.Extensions.Caching.Distributed;
 
 namespace ECommerce.Infrastructure.Services;
 
-public sealed class CacheService(IDistributedCache cache) : ICacheService
+public sealed class CacheService(IDistributedCache cache) : ICacheService, ISingletonDependency
 {
     public async Task<T?> GetAsync<T>(string key)
     {

--- a/src/Infrastructure/ECommerce.Infrastructure/Services/IdentityService.cs
+++ b/src/Infrastructure/ECommerce.Infrastructure/Services/IdentityService.cs
@@ -1,12 +1,13 @@
 using System.Security.Claims;
 using ECommerce.Application.Interfaces;
 using ECommerce.Domain.Entities;
+using ECommerce.SharedKernel;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
 namespace ECommerce.Infrastructure.Services;
 
-public sealed class IdentityService : IIdentityService
+public sealed class IdentityService : IIdentityService, IScopedDependency
 {
     private readonly UserManager<User> _userManager;
     private readonly RoleManager<Role> _roleManager;

--- a/src/Infrastructure/ECommerce.Infrastructure/Services/LocalizationService.cs
+++ b/src/Infrastructure/ECommerce.Infrastructure/Services/LocalizationService.cs
@@ -1,10 +1,11 @@
 using System.Text.Json;
 using System.Globalization;
 using ECommerce.Application.Interfaces;
+using ECommerce.SharedKernel;
 
 namespace ECommerce.Infrastructure.Services;
 
-public sealed class LocalizationService : ILocalizationService
+public sealed class LocalizationService : ILocalizationService, ISingletonDependency
 {
     private readonly Dictionary<string, Dictionary<string, string>> _localizedData = [];
 

--- a/src/Infrastructure/ECommerce.Infrastructure/Services/PermissionService.cs
+++ b/src/Infrastructure/ECommerce.Infrastructure/Services/PermissionService.cs
@@ -1,10 +1,11 @@
 using ECommerce.Application.Interfaces;
 using ECommerce.Application.Services;
 using ECommerce.Domain.Entities;
+using ECommerce.SharedKernel;
 
 namespace ECommerce.Infrastructure.Services;
 
-public sealed class PermissionService(IIdentityService identityService) : IPermissionService
+public sealed class PermissionService(IIdentityService identityService) : IPermissionService, IScopedDependency
 {
     public async Task<bool> HasPermissionAsync(Guid userId, string permission)
     {

--- a/src/Infrastructure/ECommerce.Persistence/DependencyInjection.cs
+++ b/src/Infrastructure/ECommerce.Persistence/DependencyInjection.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Http;
+using ECommerce.SharedKernel;
 
 namespace ECommerce.Persistence;
 
@@ -20,6 +21,7 @@ public static class DependencyInjection
         ConfigureDbContext(services, configuration);
         ConfigureIdentity(services);
         AddRepositories(services);
+        services.AddDependencies(typeof(DependencyInjection).Assembly);
         services.AddDatabaseSeeder();
 
         return services;

--- a/src/Infrastructure/ECommerce.Persistence/Repositories/CategoryRepository.cs
+++ b/src/Infrastructure/ECommerce.Persistence/Repositories/CategoryRepository.cs
@@ -1,11 +1,12 @@
 using ECommerce.Application.Repositories;
 using ECommerce.Domain.Entities;
 using ECommerce.Persistence.Contexts;
+using ECommerce.SharedKernel;
 using Microsoft.EntityFrameworkCore;
 
 namespace ECommerce.Persistence.Repositories;
 
-public sealed class CategoryRepository(ApplicationDbContext context) : BaseRepository<Category>(context), ICategoryRepository
+public sealed class CategoryRepository(ApplicationDbContext context) : BaseRepository<Category>(context), ICategoryRepository, IScopedDependency
 {
     public async Task<bool> HasProductsAsync(Guid id, CancellationToken cancellationToken = default)
     {

--- a/src/Infrastructure/ECommerce.Persistence/Repositories/OrderItemRepository.cs
+++ b/src/Infrastructure/ECommerce.Persistence/Repositories/OrderItemRepository.cs
@@ -1,11 +1,12 @@
 using ECommerce.Application.Repositories;
 using ECommerce.Domain.Entities;
 using ECommerce.Persistence.Contexts;
+using ECommerce.SharedKernel;
 using Microsoft.EntityFrameworkCore;
 
 namespace ECommerce.Persistence.Repositories;
 
-public sealed class OrderItemRepository(ApplicationDbContext context) : BaseRepository<OrderItem>(context), IOrderItemRepository
+public sealed class OrderItemRepository(ApplicationDbContext context) : BaseRepository<OrderItem>(context), IOrderItemRepository, IScopedDependency
 {
     public async Task<IEnumerable<OrderItem>> GetOrderItemsAsync(Guid orderId, CancellationToken cancellationToken = default)
     {

--- a/src/Infrastructure/ECommerce.Persistence/Repositories/OrderRepository.cs
+++ b/src/Infrastructure/ECommerce.Persistence/Repositories/OrderRepository.cs
@@ -1,11 +1,12 @@
 using ECommerce.Application.Repositories;
 using ECommerce.Domain.Entities;
 using ECommerce.Persistence.Contexts;
+using ECommerce.SharedKernel;
 using Microsoft.EntityFrameworkCore;
 
 namespace ECommerce.Persistence.Repositories;
 
-public sealed class OrderRepository(ApplicationDbContext context) : BaseRepository<Order>(context), IOrderRepository
+public sealed class OrderRepository(ApplicationDbContext context) : BaseRepository<Order>(context), IOrderRepository, IScopedDependency
 {
     public async Task<IEnumerable<Order>> GetUserOrdersAsync(Guid userId, CancellationToken cancellationToken = default)
     {

--- a/src/Infrastructure/ECommerce.Persistence/Repositories/ProductRepository.cs
+++ b/src/Infrastructure/ECommerce.Persistence/Repositories/ProductRepository.cs
@@ -1,9 +1,10 @@
 using ECommerce.Application.Repositories;
 using ECommerce.Domain.Entities;
 using ECommerce.Persistence.Contexts;
+using ECommerce.SharedKernel;
 
 namespace ECommerce.Persistence.Repositories;
 
-public sealed class ProductRepository(ApplicationDbContext context) : BaseRepository<Product>(context), IProductRepository
+public sealed class ProductRepository(ApplicationDbContext context) : BaseRepository<Product>(context), IProductRepository, IScopedDependency
 {
 }

--- a/src/Infrastructure/ECommerce.Persistence/Repositories/StockRepository.cs
+++ b/src/Infrastructure/ECommerce.Persistence/Repositories/StockRepository.cs
@@ -2,13 +2,14 @@ using ECommerce.Application.Exceptions;
 using ECommerce.Application.Repositories;
 using ECommerce.Domain.Entities;
 using ECommerce.Persistence.Contexts;
+using ECommerce.SharedKernel;
 using Microsoft.EntityFrameworkCore;
 
 namespace ECommerce.Persistence.Repositories;
 
 public sealed class StockRepository(ApplicationDbContext context) :
  BaseRepository<ProductStock>(context),
-  IStockRepository
+  IStockRepository, IScopedDependency
 {
     public async Task ReserveStockAsync(Guid productId, int quantity, CancellationToken cancellationToken = default)
     {

--- a/src/Infrastructure/ECommerce.Persistence/Repositories/UserAddressRepository.cs
+++ b/src/Infrastructure/ECommerce.Persistence/Repositories/UserAddressRepository.cs
@@ -1,11 +1,12 @@
 using ECommerce.Application.Repositories;
 using ECommerce.Domain.Entities;
 using ECommerce.Persistence.Contexts;
+using ECommerce.SharedKernel;
 using Microsoft.EntityFrameworkCore;
 
 namespace ECommerce.Persistence.Repositories;
 
-public sealed class UserAddressRepository(ApplicationDbContext context) : BaseRepository<UserAddress>(context), IUserAddressRepository
+public sealed class UserAddressRepository(ApplicationDbContext context) : BaseRepository<UserAddress>(context), IUserAddressRepository, IScopedDependency
 {
     public async Task<UserAddress?> GetDefaultAddressAsync(Guid userId, CancellationToken cancellationToken = default)
     {

--- a/src/Infrastructure/ECommerce.Persistence/Services/UnitOfWork.cs
+++ b/src/Infrastructure/ECommerce.Persistence/Services/UnitOfWork.cs
@@ -1,10 +1,11 @@
 using ECommerce.Application.Interfaces;
 using ECommerce.Persistence.Contexts;
+using ECommerce.SharedKernel;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace ECommerce.Persistence.Services;
 
-public sealed class UnitOfWork(ApplicationDbContext context) : IUnitOfWork
+public sealed class UnitOfWork(ApplicationDbContext context) : IUnitOfWork, IScopedDependency
 {
     public async Task<IDbContextTransaction> BeginTransactionAsync() => await context.Database.BeginTransactionAsync();
 

--- a/src/Presentation/ECommerce.WebAPI/DependencyInjection.cs
+++ b/src/Presentation/ECommerce.WebAPI/DependencyInjection.cs
@@ -46,6 +46,7 @@ public static class DependencyInjection
         services.AddApplication()
             .AddInfrastructure(configuration)
             .AddPersistence(configuration);
+        services.AddDependencies(typeof(DependencyInjection).Assembly);
 
         services.AddScoped<ICurrentUserService, CurrentUserService>();
         services.AddTransient<ILazyServiceProvider, LazyServiceProvider>();

--- a/src/Presentation/ECommerce.WebAPI/Services/CurrentUserService.cs
+++ b/src/Presentation/ECommerce.WebAPI/Services/CurrentUserService.cs
@@ -1,10 +1,11 @@
 using System.Security.Claims;
 using ECommerce.Application.Interfaces;
+using ECommerce.SharedKernel;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 
 namespace ECommerce.WebAPI.Services;
 
-public sealed class CurrentUserService(IHttpContextAccessor httpContextAccessor) : ICurrentUserService
+public sealed class CurrentUserService(IHttpContextAccessor httpContextAccessor) : ICurrentUserService, IScopedDependency
 {
     public string? UserId
         => httpContextAccessor.HttpContext?.User.FindFirst(Claims.Subject)?.Value;


### PR DESCRIPTION
## Summary
- add `IScopedDependency`, `ISingletonDependency` and `ITransientDependency`
- create `DependencyInjectionExtensions.AddDependencies` using Scrutor
- mark infrastructure and application services with lifetime markers
- scan assemblies for these markers in each dependency injection setup

## Testing
- `dotnet build ECommerce.sln -c Release` *(fails: `dotnet` not found)*
- `dotnet test ECommerce.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685148c494948321bee1fda229c65254