### PR TITLE
Add specification pattern base infrastructure

### DIFF
--- a/src/Core/ECommerce.SharedKernel/ECommerce.SharedKernel.csproj
+++ b/src/Core/ECommerce.SharedKernel/ECommerce.SharedKernel.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Scrutor" />
     <PackageReference Include="Ardalis.Result" />
     <PackageReference Include="MediatR" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
   </ItemGroup>
 
 </Project>

--- a/src/Core/ECommerce.SharedKernel/IRepository.cs
+++ b/src/Core/ECommerce.SharedKernel/IRepository.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using Ardalis.Result;
+using ECommerce.SharedKernel.Specifications;
 namespace ECommerce.SharedKernel;
 
 public interface IRepository<TEntity>
@@ -46,4 +47,10 @@ public interface IRepository<TEntity>
     void Delete(TEntity entity);
 
     void DeleteRange(IEnumerable<TEntity> entities);
+
+    IQueryable<TEntity> ApplySpecification(ISpecification<TEntity> specification);
+
+    Task<List<TEntity>> ListAsync(ISpecification<TEntity> specification, CancellationToken cancellationToken = default);
+
+    Task<TEntity?> FirstOrDefaultAsync(ISpecification<TEntity> specification, CancellationToken cancellationToken = default);
 }

--- a/src/Core/ECommerce.SharedKernel/Specifications/BaseSpecification.cs
+++ b/src/Core/ECommerce.SharedKernel/Specifications/BaseSpecification.cs
@@ -1,0 +1,34 @@
+using System.Linq.Expressions;
+
+namespace ECommerce.SharedKernel.Specifications;
+
+public abstract class BaseSpecification<T> : ISpecification<T>
+{
+    public Expression<Func<T, bool>>? Criteria { get; protected set; }
+    public List<Expression<Func<T, object>>> Includes { get; } = [];
+    public List<string> IncludeStrings { get; } = [];
+    public Expression<Func<T, object>>? OrderBy { get; protected set; }
+    public Expression<Func<T, object>>? OrderByDescending { get; protected set; }
+    public int Take { get; protected set; }
+    public int Skip { get; protected set; }
+    public bool IsPagingEnabled { get; protected set; }
+
+    protected virtual void AddInclude(Expression<Func<T, object>> includeExpression)
+        => Includes.Add(includeExpression);
+
+    protected virtual void AddInclude(string includeString)
+        => IncludeStrings.Add(includeString);
+
+    protected virtual void ApplyPaging(int skip, int take)
+    {
+        Skip = skip;
+        Take = take;
+        IsPagingEnabled = true;
+    }
+
+    protected virtual void ApplyOrderBy(Expression<Func<T, object>> orderByExpression)
+        => OrderBy = orderByExpression;
+
+    protected virtual void ApplyOrderByDescending(Expression<Func<T, object>> orderByDescendingExpression)
+        => OrderByDescending = orderByDescendingExpression;
+}

--- a/src/Core/ECommerce.SharedKernel/Specifications/ISpecification.cs
+++ b/src/Core/ECommerce.SharedKernel/Specifications/ISpecification.cs
@@ -1,0 +1,15 @@
+using System.Linq.Expressions;
+
+namespace ECommerce.SharedKernel.Specifications;
+
+public interface ISpecification<T>
+{
+    Expression<Func<T, bool>>? Criteria { get; }
+    List<Expression<Func<T, object>>> Includes { get; }
+    List<string> IncludeStrings { get; }
+    Expression<Func<T, object>>? OrderBy { get; }
+    Expression<Func<T, object>>? OrderByDescending { get; }
+    int Take { get; }
+    int Skip { get; }
+    bool IsPagingEnabled { get; }
+}

--- a/src/Core/ECommerce.SharedKernel/Specifications/SpecificationEvaluator.cs
+++ b/src/Core/ECommerce.SharedKernel/Specifications/SpecificationEvaluator.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace ECommerce.SharedKernel.Specifications;
+
+public static class SpecificationEvaluator<T> where T : class
+{
+    public static IQueryable<T> GetQuery(IQueryable<T> inputQuery, ISpecification<T> specification)
+    {
+        var query = inputQuery;
+
+        if (specification.Criteria is not null)
+        {
+            query = query.Where(specification.Criteria);
+        }
+
+        foreach (var include in specification.Includes)
+        {
+            query = query.Include(include);
+        }
+
+        foreach (var includeString in specification.IncludeStrings)
+        {
+            query = query.Include(includeString);
+        }
+
+        if (specification.OrderBy is not null)
+        {
+            query = query.OrderBy(specification.OrderBy);
+        }
+        else if (specification.OrderByDescending is not null)
+        {
+            query = query.OrderByDescending(specification.OrderByDescending);
+        }
+
+        if (specification.IsPagingEnabled)
+        {
+            query = query.Skip(specification.Skip).Take(specification.Take);
+        }
+
+        return query;
+    }
+}

--- a/src/Infrastructure/ECommerce.Persistence/Repositories/BaseRepository.cs
+++ b/src/Infrastructure/ECommerce.Persistence/Repositories/BaseRepository.cs
@@ -5,6 +5,7 @@ using ECommerce.Application.Parameters;
 using ECommerce.Domain.Entities;
 using ECommerce.Persistence.Contexts;
 using ECommerce.SharedKernel;
+using ECommerce.SharedKernel.Specifications;
 using Microsoft.EntityFrameworkCore;
 
 namespace ECommerce.Persistence.Repositories;
@@ -134,5 +135,20 @@ public abstract class BaseRepository<TEntity> : IRepository<TEntity> where TEnti
     public virtual void Update(TEntity entity)
     {
         Table.Update(entity);
+    }
+
+    public IQueryable<TEntity> ApplySpecification(ISpecification<TEntity> specification)
+    {
+        return SpecificationEvaluator<TEntity>.GetQuery(Table.AsQueryable(), specification);
+    }
+
+    public async Task<List<TEntity>> ListAsync(ISpecification<TEntity> specification, CancellationToken cancellationToken = default)
+    {
+        return await ApplySpecification(specification).ToListAsync(cancellationToken);
+    }
+
+    public async Task<TEntity?> FirstOrDefaultAsync(ISpecification<TEntity> specification, CancellationToken cancellationToken = default)
+    {
+        return await ApplySpecification(specification).FirstOrDefaultAsync(cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary
- introduce specification base types
- extend repository interface for specification support
- implement specification methods in BaseRepository
- reference EF Core in shared kernel project

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516cfdad14832198fcb26e2672d560