### PR TITLE
Make IECommerLogger generic

### DIFF
--- a/src/Core/ECommerce.Application/Behaviors/TransactionalRequestBehavior.cs
+++ b/src/Core/ECommerce.Application/Behaviors/TransactionalRequestBehavior.cs
@@ -5,7 +5,7 @@ namespace ECommerce.Application.Behaviors;
 
 public sealed class TransactionalRequestBehavior<TRequest, TResponse>(
     IUnitOfWork unitOfWork,
-    ILogger logger)
+    IECommerLogger<TransactionalRequestBehavior<TRequest, TResponse>> logger)
  : IPipelineBehavior<TRequest, TResponse>
  where TRequest : ITransactionalRequest
 {

--- a/src/Core/ECommerce.Application/Common/Logging/IECommerLogger.cs
+++ b/src/Core/ECommerce.Application/Common/Logging/IECommerLogger.cs
@@ -1,7 +1,7 @@
 namespace ECommerce.Application.Common.Logging;
 using System;
 
-public interface ILogger
+public interface IECommerLogger
 {
     void LogInformation(string message, params object[] args);
     void LogWarning(string message, params object[] args);
@@ -11,3 +11,8 @@ public interface ILogger
     void LogError(Exception exception, string message, params object[] args);
     void LogCritical(Exception exception, string message, params object[] args);
 }
+
+public interface IECommerLogger<T> : IECommerLogger
+{
+}
+

--- a/src/Core/ECommerce.Application/Features/Configuration/Commands/UpdateEmailSettings/UpdateEmailSettingsCommandHandler.cs
+++ b/src/Core/ECommerce.Application/Features/Configuration/Commands/UpdateEmailSettings/UpdateEmailSettingsCommandHandler.cs
@@ -12,7 +12,7 @@ public sealed class UpdateEmailSettingsCommandHandler(ILazyServiceProvider lazyS
     {
         try
         {
-            var logger = LazyServiceProvider.LazyGetRequiredService<ILogger>();
+            var logger = LazyServiceProvider.LazyGetRequiredService<IECommerLogger<UpdateEmailSettingsCommandHandler>>();
             
             logger.LogInformation("Email ayarları güncelleniyor - SMTP Host: {SmtpHost}, Port: {SmtpPort}, User: {SmtpUser}", 
                 request.SmtpHost, request.SmtpPort, request.SmtpUser);
@@ -49,7 +49,7 @@ public sealed class UpdateEmailSettingsCommandHandler(ILazyServiceProvider lazyS
         }
         catch (Exception ex)
         {
-            var logger = LazyServiceProvider.LazyGetRequiredService<ILogger>();
+            var logger = LazyServiceProvider.LazyGetRequiredService<IECommerLogger<UpdateEmailSettingsCommandHandler>>();
             logger.LogError(ex, "Email ayarları güncellenirken hata oluştu: {Message}", ex.Message);
             return new UpdateEmailSettingsResponse(false, $"Hata: {ex.Message}");
         }

--- a/src/Infrastructure/ECommerce.Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/ECommerce.Infrastructure/DependencyInjection.cs
@@ -54,8 +54,8 @@ public static class DependencyInjection
 
         Log.Logger = loggerConfig.CreateLogger();
         
-        services.AddSingleton<Application.Common.Logging.ILogger>(provider =>
-                  new SerilogLogger(Log.Logger));
+        services.AddSingleton(typeof(Application.Common.Logging.IECommerLogger<>),
+                  typeof(SerilogLogger<>));
     }
 
     public static IServiceCollection AddObservability(

--- a/src/Infrastructure/ECommerce.Infrastructure/Logging/SerilogLogger.cs
+++ b/src/Infrastructure/ECommerce.Infrastructure/Logging/SerilogLogger.cs
@@ -2,7 +2,7 @@ using System.Diagnostics;
 
 namespace ECommerce.Infrastructure.Logging;
 
-public sealed class SerilogLogger(Serilog.ILogger logger) : Application.Common.Logging.ILogger
+public sealed class SerilogLogger<T>(Serilog.ILogger logger) : Application.Common.Logging.IECommerLogger<T>
 {
     public void LogInformation(string message, params object[] args)
     {

--- a/src/Infrastructure/ECommerce.Infrastructure/Services/EmailService.cs
+++ b/src/Infrastructure/ECommerce.Infrastructure/Services/EmailService.cs
@@ -11,9 +11,9 @@ namespace ECommerce.Infrastructure.Services;
 public sealed class EmailService : IEmailService, IScopedDependency
 {
     private readonly IConfiguration _configuration;
-    private readonly Application.Common.Logging.ILogger? _logger;
+    private readonly Application.Common.Logging.IECommerLogger<EmailService>? _logger;
 
-    public EmailService(IConfiguration configuration, Application.Common.Logging.ILogger? logger = null)
+    public EmailService(IConfiguration configuration, Application.Common.Logging.IECommerLogger<EmailService>? logger = null)
     {
         _configuration = configuration;
         _logger = logger;

--- a/src/Infrastructure/ECommerce.Persistence/Seeds/DatabaseSeeder.cs
+++ b/src/Infrastructure/ECommerce.Persistence/Seeds/DatabaseSeeder.cs
@@ -13,12 +13,12 @@ public sealed class DatabaseSeeder(
     ApplicationDbContext context,
     UserManager<User> userManager,
     RoleManager<Role> roleManager,
-    Application.Common.Logging.ILogger logger)
+    Application.Common.Logging.IECommerLogger<DatabaseSeeder> logger)
 {
     private readonly ApplicationDbContext _context = context;
     private readonly UserManager<User> _userManager = userManager;
     private readonly RoleManager<Role> _roleManager = roleManager;
-    private readonly Application.Common.Logging.ILogger _logger = logger;
+    private readonly Application.Common.Logging.IECommerLogger<DatabaseSeeder> _logger = logger;
 
     public async Task SeedAsync()
     {

--- a/src/Presentation/ECommerce.WebAPI/Controllers/ConfigurationController.cs
+++ b/src/Presentation/ECommerce.WebAPI/Controllers/ConfigurationController.cs
@@ -8,9 +8,9 @@ namespace ECommerce.WebAPI.Controllers;
 public sealed class ConfigurationController : BaseApiController
 {
     private readonly IEmailService _emailService;
-    private readonly Application.Common.Logging.ILogger _logger;
+    private readonly Application.Common.Logging.IECommerLogger<ConfigurationController> _logger;
 
-    public ConfigurationController(IEmailService emailService, Application.Common.Logging.ILogger logger)
+    public ConfigurationController(IEmailService emailService, Application.Common.Logging.IECommerLogger<ConfigurationController> logger)
     {
         _emailService = emailService;
         _logger = logger;

--- a/src/Presentation/ECommerce.WebAPI/Middlewares/GlobalExceptionHandlerMiddleware.cs
+++ b/src/Presentation/ECommerce.WebAPI/Middlewares/GlobalExceptionHandlerMiddleware.cs
@@ -6,7 +6,7 @@ using FluentValidation;
 
 namespace ECommerce.WebAPI.Middlewares;
 
-public sealed class GlobalExceptionHandlerMiddleware(RequestDelegate next, Application.Common.Logging.ILogger logger)
+public sealed class GlobalExceptionHandlerMiddleware(RequestDelegate next, Application.Common.Logging.IECommerLogger<GlobalExceptionHandlerMiddleware> logger)
 {
     public async Task InvokeAsync(HttpContext context)
     {


### PR DESCRIPTION
## Summary
- introduce generic `IECommerLogger<T>` and update all uses
- update Serilog adapter to implement generic interface
- register open generic logger in DI container
- apply new logger type to behaviors, services, controllers, and middleware

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c5bc333c832198d6b1f98c588cd5